### PR TITLE
Implement silent Telegram delivery option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # smtp-tg-relay
+
+This project forwards e-mails to Telegram chats using a bot. The recipient address encodes the Telegram chat ID and optional thread ID.
+
+## Recipient address format
+
+```
+<chat_id>[!<thread_id>][.<flags>]@<local_domain>
+```
+
+Example: `-1001234567890!55.s@example.com`
+
+Available flags:
+
+- `s` – send the message in *silent* mode (without notification sound).
+
+## Running tests
+
+Install requirements and run `pytest`:
+
+```bash
+pip install -r requirements.txt -r requirements-test.txt
+PYTHONPATH=. pytest
+```

--- a/tests/test_recipient.py
+++ b/tests/test_recipient.py
@@ -1,0 +1,14 @@
+import pytest
+from smtp_server import LocalRecipient
+
+@pytest.mark.parametrize("local_name,chat_id,thread_id,silent", [
+    ("-10012345.s", "-10012345", None, True),
+    ("-10012345!55.s", "-10012345", "55", True),
+    ("id12345", "12345", None, False),
+])
+def test_local_recipient_parse(local_name, chat_id, thread_id, silent):
+    recipient = LocalRecipient.parse(local_name)
+    assert recipient is not None
+    assert recipient.chat_id == chat_id
+    assert recipient.message_thread_id == thread_id
+    assert recipient.silent == silent


### PR DESCRIPTION
## Summary
- allow setting a `s` flag in the recipient local part to send Telegram messages silently
- parse silent flag in `LocalRecipient`
- pass `disable_notification` to Telegram API calls
- document the new flag in README
- add tests for local recipient parsing

## Testing
- `PYTHONPATH=. pytest -q tests/test_recipient.py`
- `PYTHONPATH=. pytest -q` *(fails: telegram.error.InvalidToken)*

------
https://chatgpt.com/codex/tasks/task_e_686a5b1dad1483278d1998c8bd19c34a